### PR TITLE
unwrapped dart

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
+[workspace]
+
 [package]
 name = "flutter_tool"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -175,10 +175,10 @@ pub fn locate_executables(
             ),
             (
                 "dart".into(),
-                ExecutableConfig::new(
-                    env.os
-                        .for_native("flutter/bin/dart", "flutter/bin/dart.bat"),
-                ),
+                ExecutableConfig::new(env.os.for_native(
+                    "flutter/bin/cache/dart-sdk/bin/dart",
+                    "flutter/bin/cache/dart-sdk/bin/dart.exe",
+                )),
             ),
         ]),
         globals_lookup_dirs: vec!["$FLUTTER_ROOT/bin".into()],


### PR DESCRIPTION
The default flutter wrapper around dart doesn't help in environments managed by proto, and it gets in the way of using standalone commands like dart compile. This patch aims to rectify that.